### PR TITLE
Semantic toggle

### DIFF
--- a/config/filament-trumbowyg.php
+++ b/config/filament-trumbowyg.php
@@ -4,4 +4,5 @@ return [
     'buttons' => [],
     'tagClasses' => [],
     'changeActiveDropdownIcon' => false,
+    'semantic' => true,
 ];

--- a/resources/views/trumbowyg.blade.php
+++ b/resources/views/trumbowyg.blade.php
@@ -69,11 +69,22 @@ $editorId = strtolower(str_replace(' ', '-', $getLabel()));
 
             @if (
                 is_null($getChangeActiveDropdownIcon()) &&
-                !is_null(config('filament-trumbowyg.changeActiveDropdownIcon')) &&
-                config('filament-trumbowyg.changeActiveDropdownIcon')
+                !is_null(config('filament-trumbowyg.changeActiveDropdownIcon'))
             )
                 options.changeActiveDropdownIcon = @json(config('filament-trumbowyg.changeActiveDropdownIcon'));
             @endif
+
+            @if (!is_null($getSemantic()))
+                options.semantic = @json($getSemantic());
+            @endif
+
+            @if (
+                is_null($getSemantic()) &&
+                !is_null(config('filament-trumbowyg.semantic'))
+            )
+                options.semantic = @json(config('filament-trumbowyg.semantic'))
+            @endif
+
 
             $(id).trumbowyg(options);
 

--- a/src/Trumbowyg.php
+++ b/src/Trumbowyg.php
@@ -5,6 +5,7 @@ namespace JKHarley\FilamentTrumbowyg;
 use Filament\Forms\Components\Concerns\HasPlaceholder;
 use JKHarley\FilamentTrumbowyg\traits\HasButtons;
 use JKHarley\FilamentTrumbowyg\traits\HasChangeActiveDropdownIcon;
+use JKHarley\FilamentTrumbowyg\traits\HasSemantic;
 use JKHarley\FilamentTrumbowyg\traits\HasTagClasses;
 
 class Trumbowyg extends \Filament\Forms\Components\Field
@@ -13,6 +14,7 @@ class Trumbowyg extends \Filament\Forms\Components\Field
     use HasButtons;
     use HasTagClasses;
     use HasChangeActiveDropdownIcon;
+    use HasSemantic;
 
     protected string $view = 'filament-trumbowyg::trumbowyg';
 }

--- a/src/traits/HasSemantic.php
+++ b/src/traits/HasSemantic.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace JKHarley\FilamentTrumbowyg\traits;
+
+use Closure;
+
+trait HasSemantic
+{
+    protected bool|Closure|null $semantic = null;
+
+    public function semantic(bool|Closure|null $semantic): static
+    {
+        $this->semantic = $semantic;
+
+        return $this;
+    }
+
+    public function getSemantic(): ?bool
+    {
+        return $this->evaluate($this->semantic);
+    }
+}


### PR DESCRIPTION
This PR allows the semantic option to be toggled from within the config file or using a chain able method on the field.

This also removed a condition which may be thrown off from booleans.